### PR TITLE
Allow rendering template outside of the device context

### DIFF
--- a/core-router.j2
+++ b/core-router.j2
@@ -8,7 +8,7 @@
 {%- with term = intf.tunnel_terminations.first() %}
 {%- if term %}
 
-{%- with remote = term.tunnel.terminations. exclude(termination_id=intf.id).first() %}
+{%- with remote = term.tunnel.terminations.exclude(termination_id=intf.id).first() %}
 {%- if remote %}
 
 {%- if intf.description != '' %}

--- a/core-router.j2
+++ b/core-router.j2
@@ -2,6 +2,10 @@
 {# j2lint: disable=jinja-statements-indentation #}
 {# j2lint: disable=single-statement-per-line #}
 
+{% if device is not defined and device_id is defined %}
+{% set device = dcim.Device.objects.get(pk=device_id) %}
+{% endif %}
+
 {# Tunnels #}
 {%- for intf in device.interfaces.filter(name__startswith='tun') %}
 


### PR DESCRIPTION
API call to render for any device:

```
curl -X 'POST' \
  'https://netbox.freifunk-duesseldorf.de/api/extras/config-templates/1/render/?format=txt' \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Token <TOKEN>' \
  -d '{
  "device_id": 21
}'
```